### PR TITLE
feat(security): Implement JWT Authentication for Write Operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,28 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-security</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.jsonwebtoken</groupId>
+    <artifactId>jjwt-api</artifactId>
+    <version>0.12.6</version>
+</dependency>
+<dependency>
+    <groupId>io.jsonwebtoken</groupId>
+    <artifactId>jjwt-impl</artifactId>
+    <version>0.12.6</version>
+    <scope>runtime</scope>
+</dependency>
+<dependency>
+    <groupId>io.jsonwebtoken</groupId>
+    <artifactId>jjwt-jackson</artifactId>
+    <version>0.12.6</version>
+    <scope>runtime</scope>
+</dependency>
     </dependencies>
 
     <build>

--- a/readme.md
+++ b/readme.md
@@ -49,9 +49,9 @@ For development and testing purposes, the following hardcoded token can be used:
 | GET         | `/recipes/newcomer`     | Get the first (newcomer) recipe    | -                 | `RecipeDto`      |
 | GET         | `/recipes/{id}`         | Get a recipe by ID                 | -                 | `RecipeDto`      |
 | GET         | `/recipes`              | Get all recipes                    | -                 | `List<RecipeDto>`|
-| POST  🔒    | `/recipes`        | Create a new recipe (Authentication Required) | `RecipeDto`         | `RecipeDto`      |
-| PATCH         | `/recipes/{id}`         |Partially update a recipe. Only include the fields you want to change. | `Partial<RecipeDto>`       | `RecipeDto`      |
-| DELETE      | `/recipes/{id}`         | Delete a recipe by ID              | -                 | -                |
+| POST   🔒    | `/recipes`        | Create a new recipe | `RecipeDto`         | `RecipeDto`      |
+| PATCH  🔒       | `/recipes/{id}`         |Partially update a recipe. Only include the fields you want to change. | `Partial<RecipeDto>`       | `RecipeDto`      |
+| DELETE 🔒      | `/recipes/{id}`         | Delete a recipe by ID              | -                 | -                |
 
 > **Note:** Endpoints may require the correct JSON structure for `RecipeDto`.
 
@@ -69,6 +69,27 @@ A Postman collection is included to make testing the API endpoints easy. You can
 - Spring Data JPA
 - H2 Database
 - Springdoc OpenAPI
+
+## Architectural Decisions
+
+This section outlines some of the key design choices made in this project.
+
+### Authentication Strategy: Stateless JWT vs. Stateful Sessions
+
+A stateless authentication mechanism using JSON Web Tokens (JWT) was chosen over traditional stateful sessions for several key reasons:
+
+* **Scalability:** Stateless tokens do not require the server to store session information. This makes it much easier to scale the application horizontally by adding more server instances without worrying about session replication or sticky sessions.
+* **Decoupling:** The token is self-contained. This makes it ideal for modern, decoupled architectures where multiple clients (e.g., a web frontend, a mobile app) might consume the API.
+* **Industry Standard:** JWT Bearer authentication is the de-facto standard for securing modern RESTful APIs.
+
+### Key Implementation Components
+
+The security is implemented using the following core Spring and project components:
+
+* **`pom.xml`:** Includes the `spring-boot-starter-security` and `jjwt` dependencies to bring in the necessary libraries.
+* **`SecurityConfig.java`:** The central configuration class where the Spring Security filter chain is defined. It disables CSRF, sets the session management policy to `STATELESS`, and defines which endpoints are protected.
+* **`JwtAuthenticationFilter.java`:** A custom filter that runs on every request. It is responsible for inspecting the `Authorization` header, validating the JWT, and setting the user's authentication context within Spring Security.
+* **`springdoc-openapi` Annotations:** The `@SecurityScheme` and `@SecurityRequirement` annotations are used in the main application class (`ApiApplication.java`) and controllers (`RecipeController.java`) to accurately document the security requirements in the Swagger UI.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,16 @@ A Spring Boot REST API for managing recipes, built with Java 17, Spring Data JPA
    - Swagger UI: [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html#/)
    - H2 Console: [http://localhost:8080/h2-console](http://localhost:8080/h2-console)
 
+## Authentication
+
+Protected endpoints on this API require a Bearer Token to be sent in the `Authorization` header.
+
+**Header Format:**
+`Authorization: Bearer <your_token>`
+
+For development and testing purposes, the following hardcoded token can be used:
+`my-super-secret-jwt-token-for-testing`
+
 ## API Endpoints
 
 | HTTP Method | Endpoint                | Description                        | Request Body      | Response         |
@@ -39,7 +49,7 @@ A Spring Boot REST API for managing recipes, built with Java 17, Spring Data JPA
 | GET         | `/recipes/newcomer`     | Get the first (newcomer) recipe    | -                 | `RecipeDto`      |
 | GET         | `/recipes/{id}`         | Get a recipe by ID                 | -                 | `RecipeDto`      |
 | GET         | `/recipes`              | Get all recipes                    | -                 | `List<RecipeDto>`|
-| POST        | `/recipes`              | Create a new recipe                | `RecipeDto`       | `RecipeDto`      |
+| POST  🔒    | `/recipes`        | Create a new recipe (Authentication Required) | `RecipeDto`         | `RecipeDto`      |
 | PATCH         | `/recipes/{id}`         |Partially update a recipe. Only include the fields you want to change. | `Partial<RecipeDto>`       | `RecipeDto`      |
 | DELETE      | `/recipes/{id}`         | Delete a recipe by ID              | -                 | -                |
 

--- a/src/main/java/com/recetop/api/ApiApplication.java
+++ b/src/main/java/com/recetop/api/ApiApplication.java
@@ -1,7 +1,6 @@
 package com.recetop.api;
 
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/recetop/api/ApiApplication.java
+++ b/src/main/java/com/recetop/api/ApiApplication.java
@@ -1,9 +1,20 @@
 package com.recetop.api;
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+// 1. Define the security scheme we are using
+@SecurityScheme(
+    name = "bearerAuth",
+    type = SecuritySchemeType.HTTP,
+    bearerFormat = "JWT",
+    scheme = "bearer"
+)
+
 public class ApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/recetop/api/config/SecurityConfig.java
+++ b/src/main/java/com/recetop/api/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package com.recetop.api.config;
+
+import com.recetop.api.security.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    // 1. Inject our custom JWT filter
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+            // 2. Update the authorization rules
+            .authorizeHttpRequests(authorize -> authorize
+                // Rule 1: Any POST request to /recipes MUST be authenticated.
+                .requestMatchers(HttpMethod.POST, "/recipes").authenticated()
+                // Rule 2: Any other request to any other endpoint is permitted.
+                .anyRequest().permitAll()
+            )
+
+            // 3. Add our custom JWT filter to the chain
+            // It will run before the standard username/password filter.
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/recetop/api/config/SecurityConfig.java
+++ b/src/main/java/com/recetop/api/config/SecurityConfig.java
@@ -30,9 +30,11 @@ public class SecurityConfig {
 
             // 2. Update the authorization rules
             .authorizeHttpRequests(authorize -> authorize
-                // Rule 1: Any POST request to /recipes MUST be authenticated.
-                .requestMatchers(HttpMethod.POST, "/recipes").authenticated()
-                // Rule 2: Any other request to any other endpoint is permitted.
+       // Secure POST, PATCH, and DELETE methods for /recipes
+            .requestMatchers(HttpMethod.POST, "/recipes").authenticated()
+            .requestMatchers(HttpMethod.PATCH, "/recipes/{id}").authenticated()
+            .requestMatchers(HttpMethod.DELETE, "/recipes/{id}").authenticated()
+            // Rule 2: Any other request to any other endpoint is permitted.
                 .anyRequest().permitAll()
             )
 

--- a/src/main/java/com/recetop/api/controller/RecipeController.java
+++ b/src/main/java/com/recetop/api/controller/RecipeController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import java.util.Arrays;
 import java.util.List;
@@ -50,6 +51,7 @@ public class RecipeController {
         }
 
     @PostMapping
+    @SecurityRequirement(name = "bearerAuth")
     public RecipeDto createRecipe(@RequestBody RecipeDto recipeDto) {
         
       logger.debug("Received request to create recipe with name: '{}'", recipeDto.getName());

--- a/src/main/java/com/recetop/api/controller/RecipeController.java
+++ b/src/main/java/com/recetop/api/controller/RecipeController.java
@@ -59,12 +59,14 @@ public class RecipeController {
     }
 
     @PatchMapping("/{id}")
+    @SecurityRequirement(name = "bearerAuth")
     public RecipeDto updateRecipe(@PathVariable Long id, @RequestBody RecipeDto recipeDto) {
         
         return recipeService.updateRecipe(id, recipeDto);
     }
 
     @DeleteMapping("/{id}") 
+    @SecurityRequirement(name = "bearerAuth")
     public void deleteRecipe(@PathVariable Long id) {
         
         recipeService.deleteRecipe(id);

--- a/src/main/java/com/recetop/api/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/recetop/api/security/JwtAuthenticationFilter.java
@@ -59,6 +59,7 @@ protected void doFilterInternal(
         // --- TOKEN IS PRESENT BUT INVALID ---
         // Reject the request immediately.
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
         response.getWriter().write("{\"error\": \"Invalid or Expired Token\"}");
         // IMPORTANT: We do NOT continue the filter chain here.
     }

--- a/src/main/java/com/recetop/api/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/recetop/api/security/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.recetop.api.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component // Marks this as a Spring component to be managed by the application context
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    // --- THIS IS OUR TEMPORARY, HARDCODED TOKEN ---
+    // In a real application, you would validate this using a secret key.
+    private static final String HARDCODED_TOKEN = "my-super-secret-jwt-token-for-testing";
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        // 1. Get the Authorization header from the incoming request.
+        final String authHeader = request.getHeader("Authorization");
+
+        // 2. Check if the header is null or doesn't start with "Bearer "
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            // If it's not a valid Bearer token, pass the request to the next filter and exit.
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 3. Extract the token from the header (remove "Bearer ").
+        final String jwt = authHeader.substring(7);
+
+        // 4. Validate the token. For now, we just check if it matches our hardcoded token.
+        if (jwt.equals(HARDCODED_TOKEN)) {
+            // If the token is valid, we need to tell Spring Security that the user is authenticated.
+
+            // We create a dummy UserDetails object since we don't have a user database yet.
+            UserDetails userDetails = new User("hardcoded-user", "", Collections.emptyList());
+
+            // Create an authentication token.
+            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                    userDetails,
+                    null,
+                    userDetails.getAuthorities()
+            );
+
+            // Set the authentication token in the SecurityContext.
+            // This is the crucial step that marks the current user as authenticated.
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
+
+        // 5. Pass the request and response to the next filter in the chain.
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/recetop/api/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/recetop/api/security/JwtAuthenticationFilter.java
@@ -22,45 +22,45 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     // In a real application, you would validate this using a secret key.
     private static final String HARDCODED_TOKEN = "my-super-secret-jwt-token-for-testing";
 
-    @Override
-    protected void doFilterInternal(
-            @NonNull HttpServletRequest request,
-            @NonNull HttpServletResponse response,
-            @NonNull FilterChain filterChain) throws ServletException, IOException {
+   @Override
+protected void doFilterInternal(
+        @NonNull HttpServletRequest request,
+        @NonNull HttpServletResponse response,
+        @NonNull FilterChain filterChain) throws ServletException, IOException {
 
-        // 1. Get the Authorization header from the incoming request.
-        final String authHeader = request.getHeader("Authorization");
+    final String authHeader = request.getHeader("Authorization");
 
-        // 2. Check if the header is null or doesn't start with "Bearer "
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            // If it's not a valid Bearer token, pass the request to the next filter and exit.
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        // 3. Extract the token from the header (remove "Bearer ").
-        final String jwt = authHeader.substring(7);
-
-        // 4. Validate the token. For now, we just check if it matches our hardcoded token.
-        if (jwt.equals(HARDCODED_TOKEN)) {
-            // If the token is valid, we need to tell Spring Security that the user is authenticated.
-
-            // We create a dummy UserDetails object since we don't have a user database yet.
-            UserDetails userDetails = new User("hardcoded-user", "", Collections.emptyList());
-
-            // Create an authentication token.
-            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-                    userDetails,
-                    null,
-                    userDetails.getAuthorities()
-            );
-
-            // Set the authentication token in the SecurityContext.
-            // This is the crucial step that marks the current user as authenticated.
-            SecurityContextHolder.getContext().setAuthentication(authToken);
-        }
-
-        // 5. Pass the request and response to the next filter in the chain.
+    // If there is no token, let the request continue.
+    // Spring Security will block it later if the endpoint is protected.
+    if (authHeader == null || !authHeader.startsWith("Bearer ")) {
         filterChain.doFilter(request, response);
+        return;
     }
+
+    // A Bearer token is present. We must validate it now.
+    final String jwt = authHeader.substring(7);
+
+    if (jwt.equals(HARDCODED_TOKEN)) {
+        // --- TOKEN IS VALID ---
+        // Create a dummy UserDetails object
+        UserDetails userDetails = new User("hardcoded-user", "", Collections.emptyList());
+
+        // Create an authentication token and set it in the context
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        // Continue the filter chain
+        filterChain.doFilter(request, response);
+    } else {
+        // --- TOKEN IS PRESENT BUT INVALID ---
+        // Reject the request immediately.
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getWriter().write("{\"error\": \"Invalid or Expired Token\"}");
+        // IMPORTANT: We do NOT continue the filter chain here.
+    }
+}
 }


### PR DESCRIPTION
This Pull Request introduces the foundational JWT-based security layer to the API. The primary goal is to protect all endpoints that create, modify, or delete data (CUD operations), ensuring that only authorized requests can perform these actions.

This implementation uses a hardcoded Bearer token for validation, laying the groundwork for a more dynamic authentication system in the future.

### Key Changes Implemented

* **Dependencies Added:**
    * `spring-boot-starter-security` and `jjwt` have been added to the `pom.xml` to support security and JWT handling.

* **Core Security Components:**
    * A new `SecurityConfig.java` class configures the main security filter chain, disabling CSRF and enforcing a `STATELESS` session policy, which is ideal for a REST API.
    * A custom `JwtAuthenticationFilter.java` has been created to intercept all incoming requests, check for a valid `Authorization: Bearer <token>` header, and update the Spring Security context if the token is valid.

* **Endpoint Protection:**
    * The following endpoints are now protected and require a valid token:
        * `POST /recipes`
        * `PATCH /recipes/{id}`
        * `DELETE /recipes/{id}`

* **Documentation Updates:**
    * The `README.md` has been updated with a new **Authentication** section explaining how to authorize requests using the hardcoded token.
    * The Swagger UI documentation has been updated with `@SecurityRequirement` annotations to visually indicate protected endpoints with a lock icon (🔒) and to enable authorization through the UI.

### How to Test This Feature

1.  **Test Unauthorized Access (403 Forbidden):**
    * In Postman or the Swagger UI, make a `POST`, `PATCH`, or `DELETE` request to `/recipes` **without** providing an `Authorization` header.
    * **Expected Result:** The request should fail with a `403 Forbidden` status.

2.  **Test Authorized Access (Success):**
    * In Postman or the Swagger UI, make a `POST`, `PATCH`, or `DELETE` request.
    * Add the following `Authorization` header: `Bearer my-super-secret-jwt-token-for-testing`
    * **Expected Result:** The request should now succeed with a `2xx` status code.