### PR TITLE
Chore/rate limit test fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,7 @@ The response for a paginated endpoint is a `Page` object, which has the followin
     "first": true,
     "empty": false
 }
-
+```
 ## Testing with Postman
 
 A Postman collection is included to make testing the API endpoints easy. You can import the collection to your Postman client to get started right away.

--- a/src/main/java/com/recetop/api/controller/TestingController.java
+++ b/src/main/java/com/recetop/api/controller/TestingController.java
@@ -1,0 +1,28 @@
+package com.recetop.api.controller;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import javax.cache.CacheManager;
+import java.util.Objects;
+
+@RestController
+@RequestMapping("/testing")
+@Profile("test")
+public class TestingController {
+
+    private final CacheManager cacheManager;
+
+    public TestingController(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    @PostMapping("/reset-rate-limiter")
+    public ResponseEntity<Void> resetRateLimiter() {
+        // The cache name "buckets" comes from your ehcache.xml
+        Objects.requireNonNull(cacheManager.getCache("buckets")).clear();
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/test/java/com/recetop/api/recipes/RecipesKarateTest.java
+++ b/src/test/java/com/recetop/api/recipes/RecipesKarateTest.java
@@ -1,7 +1,9 @@
 package com.recetop.api.recipes;
 
 import com.intuit.karate.junit5.Karate;
+import org.springframework.test.context.ActiveProfiles; // Import this
 
+@ActiveProfiles("test") 
 class RecipesKarateTest {
 
     @Karate.Test

--- a/src/test/java/com/recetop/api/recipes/callable-get.feature
+++ b/src/test/java/com/recetop/api/recipes/callable-get.feature
@@ -1,0 +1,7 @@
+Feature: Reusable GET call
+
+Scenario:
+  * url 'http://localhost:8080'
+  * path '/recipes'
+  * method get
+  * status 200

--- a/src/test/java/com/recetop/api/recipes/ratelimit.feature
+++ b/src/test/java/com/recetop/api/recipes/ratelimit.feature
@@ -1,28 +1,19 @@
-Feature: API Rate Limiting
+Feature: Rate Limit Testing
 
 Background:
   * url 'http://localhost:8080'
+  * path '/testing/reset-rate-limiter'
+  * method post
+  * status 204
 
-Scenario: Verify requests are blocked after exceeding the rate limit
+Scenario: Exceeding the rate limit returns a 429 error
+  # Given the API endpoint for recipes
+  * url 'http://localhost:8080'
+  * path '/recipes'
 
-  # Define a JavaScript function that calls our other feature file 10 times
-  * def make_10_requests =
-    """
-    function() {
-      for (var i = 0; i < 10; i++) {
-        karate.log('Making successful request #', i + 1);
-        var result = karate.call('classpath:com/recetop/api/recipes/get-all-recipes.feature');
-        // We can even add an assertion here to make sure the first 10 calls succeed
-        if (result.responseStatus !== 200) {
-          karate.fail('Request number ' + (i + 1) + ' failed unexpectedly');
-        }
-      }
-    }
-    """
-  # Execute the function to consume all the tokens
-  * call make_10_requests
+  # When I make 10 successful calls
+  * karate.repeat(10, function(){ karate.call('classpath:com/recetop/api/recipes/callable-get.feature') })
 
-  # Now, make the 11th request. This one should be blocked.
-  Given path '/recipes'
-  When method GET
-  Then status 429
+  # Then the 11th call should be blocked
+  * method get
+  * status 429


### PR DESCRIPTION
This pull request resolves an issue with flaky Karate tests for the API's rate-limiting feature. It introduces a programmatic state reset mechanism to ensure that the rate-limit tests are reliable and independent of other tests.